### PR TITLE
Run7/step01

### DIFF
--- a/Run7/step01/README.md
+++ b/Run7/step01/README.md
@@ -1,0 +1,1 @@
+step01 configuration files

--- a/Run7/step01/bias10.cfg
+++ b/Run7/step01/bias10.cfg
@@ -1,0 +1,7 @@
+# BOT EO configuration file
+
+[ACQUIRE]
+bias
+
+[BIAS]
+COUNT=10  # number of bias frames, for BIAS image & noise analysis

--- a/Run7/step01/dark.cfg
+++ b/Run7/step01/dark.cfg
@@ -13,7 +13,6 @@ COUNT=3             # number of bias frames, for BIAS image & noise analysis
 [DARK]
 #ANNOTATION=Just half
 # LOCATIONS=R11,R12,R13,R12,R13,R14,R22,R23,R24,R32,R33,R34,R42,R43,R44
-#SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
 # LOCATIONS  =   R01
 BCOUNT=    1        # number of bias frames per dark set
 dark= 360.0   2    # integration time and image count for dark set

--- a/Run7/step01/dark.cfg
+++ b/Run7/step01/dark.cfg
@@ -1,0 +1,19 @@
+# BOT EO configuration file
+
+[ACQUIRE]
+#bias
+dark
+
+
+[BIAS]
+#ANNOTATION=Just half
+#LOCATIONS=R02,R03,R04,R12,R13,R14,R22,R23,R24,R32,R33,R34,R42,R43,R44
+COUNT=3             # number of bias frames, for BIAS image & noise analysis
+
+[DARK]
+#ANNOTATION=Just half
+# LOCATIONS=R11,R12,R13,R12,R13,R14,R22,R23,R24,R32,R33,R34,R42,R43,R44
+#SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+# LOCATIONS  =   R01
+BCOUNT=    1        # number of bias frames per dark set
+dark= 360.0   2    # integration time and image count for dark set

--- a/Run7/step01/dark15sx100.cfg
+++ b/Run7/step01/dark15sx100.cfg
@@ -9,6 +9,5 @@ dark
 COUNT=5             # number of bias frames, for BIAS image & noise analysis
 
 [DARK]
-#SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
 BCOUNT=    0        # number of bias frames per dark set
 dark=  15.0   100   # integration time and image count for dark set

--- a/Run7/step01/dark15sx100.cfg
+++ b/Run7/step01/dark15sx100.cfg
@@ -1,0 +1,14 @@
+# BOT EO configuration file
+
+[ACQUIRE]
+bias
+dark
+
+
+[BIAS]
+COUNT=5             # number of bias frames, for BIAS image & noise analysis
+
+[DARK]
+#SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT=    0        # number of bias frames per dark set
+dark=  15.0   100   # integration time and image count for dark set

--- a/Run7/step01/dark16sx100.cfg
+++ b/Run7/step01/dark16sx100.cfg
@@ -1,0 +1,13 @@
+# BOT EO configuration file
+
+[ACQUIRE]
+bias
+dark
+
+[BIAS]
+COUNT=5             # number of bias frames, for BIAS image & noise analysis
+
+[DARK]
+#SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT=    0        # number of bias frames per dark set
+dark=  16.0   100   # integration time and image count for dark set

--- a/Run7/step01/dark16sx100.cfg
+++ b/Run7/step01/dark16sx100.cfg
@@ -8,6 +8,5 @@ dark
 COUNT=5             # number of bias frames, for BIAS image & noise analysis
 
 [DARK]
-#SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
 BCOUNT=    0        # number of bias frames per dark set
 dark=  16.0   100   # integration time and image count for dark set

--- a/Run7/step01/dark1mx100.cfg
+++ b/Run7/step01/dark1mx100.cfg
@@ -8,6 +8,5 @@ dark
 COUNT=5             # number of bias frames, for BIAS image & noise analysis
 
 [DARK]
-SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
 BCOUNT=    0        # number of bias frames per dark set
 dark=  60.0   100   # integration time and image count for dark set

--- a/Run7/step01/dark1mx100.cfg
+++ b/Run7/step01/dark1mx100.cfg
@@ -1,0 +1,13 @@
+# BOT EO configuration file
+
+[ACQUIRE]
+bias
+dark
+
+[BIAS]
+COUNT=5             # number of bias frames, for BIAS image & noise analysis
+
+[DARK]
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT=    0        # number of bias frames per dark set
+dark=  60.0   100   # integration time and image count for dark set

--- a/Run7/step01/dark1mx5.cfg
+++ b/Run7/step01/dark1mx5.cfg
@@ -1,0 +1,13 @@
+# BOT EO configuration file
+
+[ACQUIRE]
+bias
+dark
+
+[BIAS]
+COUNT=5             # number of bias frames, for BIAS image & noise analysis
+
+[DARK]
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT=    0        # number of bias frames per dark set
+dark=  60.0   5    # integration time and image count for dark set

--- a/Run7/step01/dark1mx5.cfg
+++ b/Run7/step01/dark1mx5.cfg
@@ -8,6 +8,5 @@ dark
 COUNT=5             # number of bias frames, for BIAS image & noise analysis
 
 [DARK]
-SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
 BCOUNT=    0        # number of bias frames per dark set
 dark=  60.0   5    # integration time and image count for dark set

--- a/Run7/step01/dark900.cfg
+++ b/Run7/step01/dark900.cfg
@@ -1,0 +1,17 @@
+# BOT EO configuration file
+
+[ACQUIRE]
+bias
+dark
+
+[BIAS]
+#ANNOTATION=Just half
+#LOCATIONS=R02,R03,R04,R12,R13,R14,R22,R23,R24,R32,R33,R34,R42,R43,R44
+COUNT=10             # number of bias frames, for BIAS image & noise analysis
+
+[DARK]
+#ANNOTATION=Just half
+#LOCATIONS=R02,R03,R04,R12,R13,R14,R22,R23,R24,R32,R33,R34,R42,R43,R44
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT=    0        # number of bias frames per dark set
+dark=  900.0   2    # integration time and image count for dark set

--- a/Run7/step01/dark900.cfg
+++ b/Run7/step01/dark900.cfg
@@ -12,6 +12,5 @@ COUNT=10             # number of bias frames, for BIAS image & noise analysis
 [DARK]
 #ANNOTATION=Just half
 #LOCATIONS=R02,R03,R04,R12,R13,R14,R22,R23,R24,R32,R33,R34,R42,R43,R44
-SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
 BCOUNT=    0        # number of bias frames per dark set
 dark=  900.0   2    # integration time and image count for dark set

--- a/Run7/step01/flats_ordered.cfg
+++ b/Run7/step01/flats_ordered.cfg
@@ -1,0 +1,61 @@
+[ACQUIRE]
+flat
+
+[FLAT]
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT=1        # number of bias frames per flat image
+WL    =red    # wavelength filter to use for the flats
+HILIM =15.0    # maximum seconds for a flat field exposure
+LOLIM =0        # minimum seconds for a flat field exposure
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+
+# DARKINTERRUPT = False # If True, will take darks between flat images 
+# DARKINTERRUPTLIST = 30  5 # integration time and image count for dark set, formatted the same as the DARK acquisition
+
+#
+# Below has pairs from 100-200,000 e/pixel, log spaced with
+# four overlapping pairs around the transition between
+# ND_OD1.0 and empty (568-1090 e/pixel)
+FLAT=15	100,
+    15	124,
+    15	154,
+    15	192,
+    15	239,
+    15	296,
+    15	368,
+    15	458,
+    15	569,
+    15	707,
+    15	879,
+    15	1092,
+    15	1357,
+    15	1687,
+    15	2096,
+    15	2605,
+    15	3237,
+    15	4023,
+    15	5000,
+    15	6214,
+    15	7722,
+    15	9597,
+    15	11927,
+    15	14822,
+    15	18420,
+    15	22892,
+    15	28449,
+    15	35355,
+    15	43938,
+    15	54605,
+    15	67860,
+    15	84334,
+    15	104807,
+    15	130250,
+    15	161870,
+    15	201165,
+    15	250000,
+    15	260000,
+    15	270000,
+    15	280000,
+    15	290000,
+    15	300000,
+    15	310000

--- a/Run7/step01/flats_randomized.cfg
+++ b/Run7/step01/flats_randomized.cfg
@@ -1,0 +1,60 @@
+[ACQUIRE]
+flat
+
+[FLAT]
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT=1        # number of bias frames per flat image
+WL    =red    # wavelength filter to use for the flats
+HILIM =15.0    # maximum seconds for a flat field exposure
+LOLIM =0        # minimum seconds for a flat field exposure
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+
+
+
+#
+# Below has pairs from 100-200,000 e/pixel, log spaced with
+# four overlapping pairs around the transition between
+# ND_OD1.0 and empty (568-1090 e/pixel)
+FLAT=15     296,  # number of electrons/pixel, ND filter
+     15     239,
+     15     154,
+     15     192,
+     15     707,
+     15     569,
+     15  310000,
+     15     124,
+     15     458,
+     15     879,
+     15	 260000,
+     15     368,
+     15     100,
+     15    2096,
+     15    1092,
+     15   35355,
+     15    1687,
+     15  280000,
+     15   11927,
+     15    1357,
+     15  104807,
+     15  130250,
+     15   28449,
+     15    7722,
+     15  250000,
+     15  161870,
+     15    9597,
+     15   67860,
+     15  201165,
+     15   54605,
+     15   18420,
+     15    6214,
+     15    3237,
+     15  300000,
+     15    4023,
+     15   14822,
+     15   84334,
+     15  290000,
+     15   43938,
+     15    5000,
+     15  270000,
+     15    2605,
+     15   22892

--- a/Run7/step01/flats_randomized.cfg
+++ b/Run7/step01/flats_randomized.cfg
@@ -58,3 +58,4 @@ FLAT=15     296,  # number of electrons/pixel, ND filter
      15  270000,
      15    2605,
      15   22892
+     


### PR DESCRIPTION
File structure determined from [confluence page](https://confluence.lsstcorp.org/display/CAM/Reverification+at+summit+plan)

Output from ```cfg_interp_Run7.py```, columns correspond to time in minutes, number of acquisitions, total image volume

```
|bias10.cfg                         |     0.5 |    10 |  0.15 |
|dark.cfg                           |    12.1 |     3 |  0.04 |
|dark15sx100.cfg                    |    29.9 |   105 |  1.57 |
|dark16sx100.cfg                    |    31.6 |   105 |  1.57 |
|dark1mx100.cfg                     |   104.9 |   105 |  1.57 |
|dark1mx5.cfg                       |     5.5 |    10 |  0.15 |
|dark900.cfg                        |    30.6 |    12 |  0.18 |
|flats.cfg                          |    30.1 |   141 |  2.11 |
```