### PR TITLE
Run7/step07

### DIFF
--- a/Run7/step07/stabilityFlats_1h_750.cfg
+++ b/Run7/step07/stabilityFlats_1h_750.cfg
@@ -1,0 +1,18 @@
+[ACQUIRE]
+bias
+sflat
+
+[BIAS]
+ACQTYPE=bias
+ANNOTATION=0 sec extra delay
+COUNT= 20
+
+[SFLAT]
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+# With 15 sec delay + 15 sec integration + 2.8 s readout, 109 flats will take 1 hour
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+BCOUNT=  0     # number of bias frames per superflat set
+HILIM = 15.0   # maximum seconds for a flat field exposure (used as exposure time)
+LOLIM =  0     # minimum seconds for a flat field exposure
+EXTRADELAY = 15
+SFLAT = nm750 25000 109  # wavelength filter, signal(e-), count

--- a/Run7/step07/stabilityFlats_1h_blue.cfg
+++ b/Run7/step07/stabilityFlats_1h_blue.cfg
@@ -1,0 +1,18 @@
+[ACQUIRE]
+bias
+sflat
+
+[BIAS]
+ACQTYPE=bias
+ANNOTATION=0 sec extra delay
+COUNT= 20
+
+[SFLAT]
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+# With 15 sec delay + 15 sec integration + 2.8 s readout, 109 flats will take 1 hour
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+BCOUNT=  0     # number of bias frames per superflat set
+HILIM = 15.0   # maximum seconds for a flat field exposure (used as exposure time)
+LOLIM =  0     # minimum seconds for a flat field exposure
+EXTRADELAY = 15
+SFLAT = blue 25000 109  # wavelength filter, signal(e-), count


### PR DESCRIPTION
File structure determined from [confluence page](https://confluence.lsstcorp.org/display/CAM/Reverification+at+summit+plan)

Output from cfg_interp_Run7.py, columns correspond to time in minutes, number of acquisitions, total image volume in TB

```
|stabilityFlats_1h_750.cfg          |    60.5 |   129 |  1.94 |
|stabilityFlats_1h_blue.cfg         |    60.5 |   129 |  1.94 |
```