### PR TITLE
Run7/step12 additions

### DIFF
--- a/Run7/step12/stabilityFlats_6h_10k.cfg
+++ b/Run7/step12/stabilityFlats_6h_10k.cfg
@@ -1,0 +1,19 @@
+
+[ACQUIRE]
+bias
+sflat
+
+[BIAS]
+ACQTYPE=bias
+ANNOTATION=0 sec extra delay
+COUNT= 20
+
+[SFLAT]
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+# With 60 sec delay + 15 sec integration + 2.8 s readout, 277 flats will take 6 hours
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+BCOUNT=  0     # number of bias frames per superflat set
+HILIM = 15.0   # maximum seconds for a flat field exposure (used as exposure time)
+LOLIM =  0     # minimum seconds for a flat field exposure
+EXTRADELAY = 60
+SFLAT = nm750 10000 277  # wavelength filter, signal(e-), count

--- a/Run7/step12/stabilityFlats_6h_50k.cfg
+++ b/Run7/step12/stabilityFlats_6h_50k.cfg
@@ -1,0 +1,19 @@
+
+[ACQUIRE]
+bias
+sflat
+
+[BIAS]
+ACQTYPE=bias
+ANNOTATION=0 sec extra delay
+COUNT= 20
+
+[SFLAT]
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+# With 60 sec delay + 15 sec integration + 2.8 s readout, 277 flats will take 6 hours
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+BCOUNT=  0     # number of bias frames per superflat set
+HILIM = 15.0   # maximum seconds for a flat field exposure (used as exposure time)
+LOLIM =  0     # minimum seconds for a flat field exposure
+EXTRADELAY = 60
+SFLAT = nm750 50000 277  # wavelength filter, signal(e-), count


### PR DESCRIPTION
Adding two stability flat files at 10k e- and 50k e-

The reasoning being to use two different levels. The gain stability has typically used 10k electrons in the center of the field of view and a 2nd, higher light level, at 50k electrons.  The reason is that the previous gain stability runs had shown about a 0.06%/C temperature coefficient.  But looking at a dense PTC with varying temperature, Eli derived a constant closer to 0.08%/C.  Studying that at two different level would help understand that better