### PR TITLE
Added Variations with no DarkInterrupt

### DIFF
--- a/Run7/step05/Persistence_large_noDarkInterrupt.cfg
+++ b/Run7/step05/Persistence_large_noDarkInterrupt.cfg
@@ -1,0 +1,839 @@
+# Dense Persistence Test going from 80,000 to 150,000 ADU in 1000 ADU steps and then 150,000 to 200,000 ADU in 10,000 ADU steps
+[ACQUIRE]
+persistence0
+persistence1
+persistence2
+persistence3
+persistence4
+persistence5
+persistence6
+persistence7
+persistence8
+persistence9
+persistence10
+persistence11
+persistence12
+persistence13
+persistence14
+persistence15
+persistence16
+persistence17
+persistence18
+persistence19
+persistence20
+persistence21
+persistence22
+persistence23
+persistence24
+persistence25
+persistence26
+persistence27
+persistence28
+persistence29
+persistence30
+persistence31
+persistence32
+persistence33
+persistence34
+persistence35
+persistence36
+persistence37
+persistence38
+persistence39
+persistence40
+persistence41
+persistence42
+persistence43
+persistence44
+persistence45
+persistence46
+persistence47
+persistence48
+persistence49
+persistence50
+persistence51
+persistence52
+persistence53
+persistence54
+persistence55
+persistence56
+persistence57
+persistence58
+persistence59
+persistence60
+persistence61
+persistence62
+persistence63
+persistence64
+persistence65
+persistence66
+persistence67
+persistence68
+persistence69
+persistence70
+persistence71
+persistence72
+persistence73
+persistence74
+persistence75
+
+
+[PERSISTENCE0]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 80000 10 15.0 0.0 
+
+
+[PERSISTENCE1]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 81000 10 15.0 0.0 
+
+
+[PERSISTENCE2]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 82000 10 15.0 0.0 
+
+
+[PERSISTENCE3]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 83000 10 15.0 0.0 
+
+
+[PERSISTENCE4]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 84000 10 15.0 0.0 
+
+
+[PERSISTENCE5]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 85000 10 15.0 0.0 
+
+
+[PERSISTENCE6]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 86000 10 15.0 0.0 
+
+
+[PERSISTENCE7]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 87000 10 15.0 0.0 
+
+
+[PERSISTENCE8]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 88000 10 15.0 0.0 
+
+
+[PERSISTENCE9]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 89000 10 15.0 0.0 
+
+
+[PERSISTENCE10]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 90000 10 15.0 0.0 
+
+
+[PERSISTENCE11]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 91000 10 15.0 0.0 
+
+
+[PERSISTENCE12]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 92000 10 15.0 0.0 
+
+
+[PERSISTENCE13]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 93000 10 15.0 0.0 
+
+
+[PERSISTENCE14]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 94000 10 15.0 0.0 
+
+
+[PERSISTENCE15]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 95000 10 15.0 0.0 
+
+
+[PERSISTENCE16]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 96000 10 15.0 0.0 
+
+
+[PERSISTENCE17]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 97000 10 15.0 0.0 
+
+
+[PERSISTENCE18]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 98000 10 15.0 0.0 
+
+
+[PERSISTENCE19]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 99000 10 15.0 0.0 
+
+
+[PERSISTENCE20]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 100000 10 15.0 0.0 
+
+
+[PERSISTENCE21]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 101000 10 15.0 0.0 
+
+
+[PERSISTENCE22]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 102000 10 15.0 0.0 
+
+
+[PERSISTENCE23]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 103000 10 15.0 0.0 
+
+
+[PERSISTENCE24]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 104000 10 15.0 0.0 
+
+
+[PERSISTENCE25]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 105000 10 15.0 0.0 
+
+
+[PERSISTENCE26]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 106000 10 15.0 0.0 
+
+
+[PERSISTENCE27]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 107000 10 15.0 0.0 
+
+
+[PERSISTENCE28]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 108000 10 15.0 0.0 
+
+
+[PERSISTENCE29]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 109000 10 15.0 0.0 
+
+
+[PERSISTENCE30]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 110000 10 15.0 0.0 
+
+
+[PERSISTENCE31]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 111000 10 15.0 0.0 
+
+
+[PERSISTENCE32]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 112000 10 15.0 0.0 
+
+
+[PERSISTENCE33]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 113000 10 15.0 0.0 
+
+
+[PERSISTENCE34]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 114000 10 15.0 0.0 
+
+
+[PERSISTENCE35]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 115000 10 15.0 0.0 
+
+
+[PERSISTENCE36]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 116000 10 15.0 0.0 
+
+
+[PERSISTENCE37]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 117000 10 15.0 0.0 
+
+
+[PERSISTENCE38]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 118000 10 15.0 0.0 
+
+
+[PERSISTENCE39]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 119000 10 15.0 0.0 
+
+
+[PERSISTENCE40]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 120000 10 15.0 0.0 
+
+
+[PERSISTENCE41]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 121000 10 15.0 0.0 
+
+
+[PERSISTENCE42]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 122000 10 15.0 0.0 
+
+
+[PERSISTENCE43]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 123000 10 15.0 0.0 
+
+
+[PERSISTENCE44]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 124000 10 15.0 0.0 
+
+
+[PERSISTENCE45]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 125000 10 15.0 0.0 
+
+
+[PERSISTENCE46]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 126000 10 15.0 0.0 
+
+
+[PERSISTENCE47]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 127000 10 15.0 0.0 
+
+
+[PERSISTENCE48]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 128000 10 15.0 0.0 
+
+
+[PERSISTENCE49]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 129000 10 15.0 0.0 
+
+
+[PERSISTENCE50]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 130000 10 15.0 0.0 
+
+
+[PERSISTENCE51]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 131000 10 15.0 0.0 
+
+
+[PERSISTENCE52]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 132000 10 15.0 0.0 
+
+
+[PERSISTENCE53]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 133000 10 15.0 0.0 
+
+
+[PERSISTENCE54]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 134000 10 15.0 0.0 
+
+
+[PERSISTENCE55]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 135000 10 15.0 0.0 
+
+
+[PERSISTENCE56]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 136000 10 15.0 0.0 
+
+
+[PERSISTENCE57]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 137000 10 15.0 0.0 
+
+
+[PERSISTENCE58]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 138000 10 15.0 0.0 
+
+
+[PERSISTENCE59]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 139000 10 15.0 0.0 
+
+
+[PERSISTENCE60]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 140000 10 15.0 0.0 
+
+
+[PERSISTENCE61]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 141000 10 15.0 0.0 
+
+
+[PERSISTENCE62]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 142000 10 15.0 0.0 
+
+
+[PERSISTENCE63]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 143000 10 15.0 0.0 
+
+
+[PERSISTENCE64]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 144000 10 15.0 0.0 
+
+
+[PERSISTENCE65]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 145000 10 15.0 0.0 
+
+
+[PERSISTENCE66]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 146000 10 15.0 0.0 
+
+
+[PERSISTENCE67]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 147000 10 15.0 0.0 
+
+
+[PERSISTENCE68]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 148000 10 15.0 0.0 
+
+
+[PERSISTENCE69]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 149000 10 15.0 0.0 
+
+
+[PERSISTENCE70]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 150000 10 15.0 0.0 
+
+
+[PERSISTENCE71]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 160000 10 15.0 0.0 
+
+
+[PERSISTENCE72]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 170000 10 15.0 0.0 
+
+
+[PERSISTENCE73]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 180000 10 15.0 0.0 
+
+
+[PERSISTENCE74]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 190000 10 15.0 0.0 
+
+
+[PERSISTENCE75]
+ACQTYPE=persistence
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 5
+WL= red
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 200000 10 15.0 0.0 
+

--- a/Run7/step05/Persistence_short_noDarkInterrupt.cfg
+++ b/Run7/step05/Persistence_short_noDarkInterrupt.cfg
@@ -1,0 +1,10 @@
+[ACQUIRE]
+persistence
+
+[PERSISTENCE]
+SHUTTER = OPEN  # Shutter opens at start of acqusition, closes at end
+BCOUNT= 0  # number of bias frames per persistence set
+WL= red      # wavelength filter
+ND = empty
+FILTERCONFIG = /home/ccs/bot-eotest-configs/Run7/calib.cfg
+PERSISTENCE= 300000 10 15.0 0.0  # signal(e-), number of darks after flat, exposure time, time(sec) between darks


### PR DESCRIPTION
I added two new files that are just the Persistence_large (Dense Persistence Sequence) and Persistence_short (Single Persistence Sequence) that do not rely on Sean's `DarkInterrupt` additions, based on what we did in Run6 (see step11 for the template).