### PR TITLE
Run7/step14

### DIFF
--- a/Run7/step14/dark_shutterClosed.cfg
+++ b/Run7/step14/dark_shutterClosed.cfg
@@ -1,0 +1,7 @@
+#  20 15sec DARK images taken with room lights off and Shutter CLOSED
+# Before executing this config, make sure shutter is closed. The SHUTTER=None keyword
+[ACQUIRE]
+dark
+[DARK]
+dark=15.0 20     # integration time and image count for dark set
+SHUTTER=None

--- a/Run7/step14/dark_shutterClosed.cfg
+++ b/Run7/step14/dark_shutterClosed.cfg
@@ -3,5 +3,6 @@
 [ACQUIRE]
 dark
 [DARK]
+BCOUNT=0
 dark=15.0 20     # integration time and image count for dark set
 SHUTTER=None

--- a/Run7/step14/dark_shutterOpen.cfg
+++ b/Run7/step14/dark_shutterOpen.cfg
@@ -1,0 +1,6 @@
+#  20 15sec DARK images taken with room lights off and Shutter OPEN
+[ACQUIRE]
+dark
+[DARK]
+dark=15.0 20     # integration time and image count for dark set
+SHUTTER=OPEN

--- a/Run7/step14/dark_shutterOpen.cfg
+++ b/Run7/step14/dark_shutterOpen.cfg
@@ -4,3 +4,4 @@ dark
 [DARK]
 dark=15.0 20     # integration time and image count for dark set
 SHUTTER=OPEN
+BCOUNT=0


### PR DESCRIPTION
From discussion on the [cam-summit-ops channel](https://lsstc.slack.com/archives/CCQBHNS0K/p1726171121007069): 

This is one of the items that needs fleshing out.  I would like the following added as a 'Step':

    DARKS with Shutter closed: 20 15sec DARK images taken with room lights off and Shutter CLOSED.  This measures the CCD dark current itself.  This previously passed our requirements, and this would be the re-verification.
    DARKS with Shutter open: 20 15sec DARK images taken with room lights off and Shutter OPEN.  This tests for stray light inside the Camera.  And verifies that the previously know sources are now mitigated.